### PR TITLE
Add optional and optionalAt

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ person : Decoder Person
 person =
     Field.require "name" Decode.string <| \name ->
     Field.require "id" Decode.int <| \id ->
-    Field.attempt "weight" Decode.int <| \maybeWeight ->
+    Field.optional "weight" Decode.int <| \maybeWeight ->
     Field.attempt "likes" Decode.int <| \maybeLikes ->
 
     Decode.succeed


### PR DESCRIPTION
These functions combines require and attempt, allowing the user to decode fields that are optional but should fail if the field exists and the data is incorrect.